### PR TITLE
Mock 데이터 통신을 위한 사전작업

### DIFF
--- a/components/Api/getCakeList.tsx
+++ b/components/Api/getCakeList.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable consistent-return */
+import internalApi from '.';
+
+export default async function getCakeList({ location, category }: any) {
+  try {
+    const response = await internalApi.post(`/api/orders`, {
+      location,
+      category,
+    });
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/components/Api/index.tsx
+++ b/components/Api/index.tsx
@@ -1,0 +1,31 @@
+import axios, { AxiosInstance } from 'axios';
+
+const setInterceptor = (instance: AxiosInstance) => {
+  instance.interceptors.response.use(
+    (response) => response,
+    (error) => {
+      if (error.code === 'ECONNABORTED' || error.response?.status === 408) {
+        alert('요청이 만료되었습니다.');
+      }
+      return Promise.reject(error);
+    }
+  );
+
+  return instance;
+};
+
+const options = {
+  headers: {
+    Accept: '*/*',
+    'Content-Type': 'application/json',
+  },
+  timeout: 10000,
+};
+
+const internalApi = setInterceptor(
+  axios.create({
+    ...options,
+  })
+);
+
+export default internalApi;

--- a/components/Api/mock/letteringGangbok.json
+++ b/components/Api/mock/letteringGangbok.json
@@ -1,0 +1,166 @@
+{
+  "data": {
+    "content": [
+      {
+        "postId": 1,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 2,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 3,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 4,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 5,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 6,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 7,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 8,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 9,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 10,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 11,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 12,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 13,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 14,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 15,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 16,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 17,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 18,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 19,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 20,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      }
+    ]
+  }
+}

--- a/components/Api/mock/letteringGangnam.json
+++ b/components/Api/mock/letteringGangnam.json
@@ -1,0 +1,166 @@
+{
+  "data": {
+    "content": [
+      {
+        "postId": 1,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 2,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 3,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 4,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 5,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 6,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 7,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 8,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 9,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 10,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 11,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 12,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 13,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 14,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 15,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 16,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 17,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 18,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 19,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 20,
+        "category": "레터링",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      }
+    ]
+  }
+}

--- a/components/Api/mock/photoGangbok.json
+++ b/components/Api/mock/photoGangbok.json
@@ -1,0 +1,166 @@
+{
+  "data": {
+    "content": [
+      {
+        "postId": 1,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코 - 강북데이터",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 2,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 3,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 4,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 5,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 6,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 7,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 8,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 9,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 10,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 11,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 12,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 13,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 14,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 15,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 16,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 17,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 18,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 19,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 20,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      }
+    ]
+  }
+}

--- a/components/Api/mock/photoGangnam.json
+++ b/components/Api/mock/photoGangnam.json
@@ -1,0 +1,166 @@
+{
+  "data": {
+    "content": [
+      {
+        "postId": 1,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코 - 강남데이터",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 2,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 3,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 4,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 5,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 6,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 7,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 8,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 9,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 10,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 11,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 12,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 13,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 14,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 15,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 16,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 17,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 18,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 19,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      },
+      {
+        "postId": 20,
+        "category": "포토",
+        "size": "1호",
+        "flavor": "초코",
+        "image": "/images/cake.png",
+        "price": "130,000"
+      }
+    ]
+  }
+}

--- a/components/Main/cakeMain.tsx
+++ b/components/Main/cakeMain.tsx
@@ -8,11 +8,17 @@ import {
   Tabs,
 } from '@chakra-ui/react';
 
+import getCakeList from '../Api/getCakeList';
 import CakeItem from './cakeItem';
 import LocationSelectBox from './locationSelectBox';
 import { ICakeList } from './types';
 
 export default function CakeMain() {
+  const data = getCakeList({
+    location: 'gangnam',
+    category: 'photo',
+  });
+  console.log(data);
   // 이후 통신할 데이터 주소를 contents로 넣어서 활용
   // Sprint 4 이후 작업
   const DUMMY_DATA: ICakeList[] = [

--- a/components/Main/cakeMain.tsx
+++ b/components/Main/cakeMain.tsx
@@ -1,12 +1,15 @@
 import {
   Box,
   Flex,
+  Grid,
   Tab,
   TabList,
   TabPanel,
   TabPanels,
   Tabs,
+  Text,
 } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
 
 import getCakeList from '../Api/getCakeList';
 import CakeItem from './cakeItem';
@@ -14,11 +17,17 @@ import LocationSelectBox from './locationSelectBox';
 import { ICakeList } from './types';
 
 export default function CakeMain() {
-  const data = getCakeList({
-    location: 'gangnam',
-    category: 'photo',
-  });
-  console.log(data);
+  const { status, data } = useQuery(['gangnam-photo'], () =>
+    getCakeList({
+      location: 'gangnam',
+      category: 'photo',
+    })
+  );
+
+  if (status === 'loading') {
+    return <span>Loading...</span>;
+  }
+
   // 이후 통신할 데이터 주소를 contents로 넣어서 활용
   // Sprint 4 이후 작업
   const DUMMY_DATA: ICakeList[] = [
@@ -68,11 +77,19 @@ export default function CakeMain() {
         </TabList>
       </Box>
       <TabPanels>
-        {DUMMY_DATA.map((tab, index) => (
+        {DUMMY_DATA.map((tab) => (
           <TabPanel p={3} key={tab.content}>
             <Flex padding={0} gap={4} flexDirection="column">
-              {tab.content}
-              {index}
+              {data.map((item: any) => (
+                <Grid>
+                  <Text>{item.postId}</Text>
+                  <Text>{item.category}</Text>
+                  <Text>{item.size}</Text>
+                  <Text>{item.flavor}</Text>
+                  <Text>{item.image}</Text>
+                  <Text>{item.price}</Text>
+                </Grid>
+              ))}
               <CakeItem />
               <CakeItem />
               <CakeItem isCompleted />

--- a/pages/api/orders.tsx
+++ b/pages/api/orders.tsx
@@ -1,0 +1,33 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import letteringGangbok from '@/components/Api/mock/letteringGangbok.json';
+import letteringGangnam from '@/components/Api/mock/letteringGangnam.json';
+import photoGangbok from '@/components/Api/mock/photoGangbok.json';
+import photoGangnam from '@/components/Api/mock/photoGangnam.json';
+
+export default async function getCakeList(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  const { location, category } = request.body;
+  if (category === 'photo') {
+    if (location === 'gangnam') {
+      return response
+        .status(200)
+        .end(JSON.stringify(photoGangnam.data.content));
+    }
+    if (location === 'gangbok') {
+      return response.status(200).end(JSON.stringify(photoGangbok));
+    }
+  }
+
+  if (category === 'lettering') {
+    if (location === 'gangnam') {
+      return response.status(200).end(JSON.stringify(letteringGangnam));
+    }
+    if (location === 'gangbok') {
+      return response.status(200).end(JSON.stringify(letteringGangbok));
+    }
+  }
+  return response.status(500).end(JSON.stringify(err));
+}

--- a/pages/api/orders.tsx
+++ b/pages/api/orders.tsx
@@ -29,5 +29,5 @@ export default async function getCakeList(
       return response.status(200).end(JSON.stringify(letteringGangbok));
     }
   }
-  return response.status(500).end(JSON.stringify(err));
+  return response.status(500).end('err');
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->
- close #46 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
 Mock 데이터를 비동기 통신을 통해 연결한다

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome_4uN38bAoVG](https://user-images.githubusercontent.com/97251710/221402513-76fd5ecc-6f34-44fd-8e1e-40e7198779d4.gif)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

1. Next의 pages/api를 활용하여 서버를 간이로 셋팅했습니다.
2. api/orders 에 post의 body로 category , location 을 설정하면 해당 값을 리턴합니다.
3. 셋팅된 데이터는 components/mock 폴더 내부에 있으며 지역은 강남과 강북 , 카테고리는 포토와 래터링만 구현해뒀습니다.
