### PR TITLE
feat: 메인 페이지와 Mock API를 연동한다

### DIFF
--- a/components/Api/getCakeList.tsx
+++ b/components/Api/getCakeList.tsx
@@ -3,7 +3,6 @@ import internalApi from '.';
 
 export default async function getCakeList({ location, category }: any) {
   try {
-    console.log(location, category);
     const response = await internalApi.post(`/api/orders/`, {
       location,
       category,

--- a/components/Api/getCakeList.tsx
+++ b/components/Api/getCakeList.tsx
@@ -1,13 +1,10 @@
 /* eslint-disable consistent-return */
 import internalApi from '.';
 
-export default async function getCakeList({
-  location,
-  category,
-  cursor = 0,
-}: any) {
+export default async function getCakeList({ location, category }: any) {
   try {
-    const response = await internalApi.post(`/api/orders/${cursor}`, {
+    console.log(location, category);
+    const response = await internalApi.post(`/api/orders/`, {
       location,
       category,
     });

--- a/components/Api/getCakeList.tsx
+++ b/components/Api/getCakeList.tsx
@@ -1,9 +1,13 @@
 /* eslint-disable consistent-return */
 import internalApi from '.';
 
-export default async function getCakeList({ location, category }: any) {
+export default async function getCakeList({
+  location,
+  category,
+  cursor = 0,
+}: any) {
   try {
-    const response = await internalApi.post(`/api/orders`, {
+    const response = await internalApi.post(`/api/orders/${cursor}`, {
       location,
       category,
     });

--- a/components/Api/getMarketDetail.tsx
+++ b/components/Api/getMarketDetail.tsx
@@ -1,0 +1,14 @@
+/* eslint-disable consistent-return */
+import internalApi from '.';
+
+export default async function getMarketDetail() {
+  try {
+    // enrollmentID = 632463
+    const response = await internalApi.get(`/api/enrollments/632463`, {});
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/components/Api/getMarketList.tsx
+++ b/components/Api/getMarketList.tsx
@@ -1,0 +1,13 @@
+/* eslint-disable consistent-return */
+import internalApi from '.';
+
+export default async function getMarketList() {
+  try {
+    const response = await internalApi.get(`/api/enrollments`, {});
+    if (response.status === 200) {
+      return response.data;
+    }
+  } catch (error) {
+    console.log(error);
+  }
+}

--- a/components/Api/mock/allGangnam.json
+++ b/components/Api/mock/allGangnam.json
@@ -1,0 +1,206 @@
+{
+  "data": {
+    "content": [
+      {
+        "orderId": 1,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-10-18:00"
+      },
+      {
+        "orderId": 2,
+        "title": "강남 케이크 제작 2",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_ONE",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-09-18:00"
+      },
+      {
+        "orderId": 3,
+        "title": "강남 케이크 제작 3",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_ONE",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-08-18:00"
+      },
+      {
+        "orderId": 4,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_TWO",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-07-18:00"
+      },
+      {
+        "orderId": 5,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_TWO",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-06-18:00"
+      },
+      {
+        "orderId": 6,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-05-18:00"
+      },
+      {
+        "orderId": 7,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-04-18:00"
+      },
+      {
+        "orderId": 8,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-03-18:00"
+      },
+      {
+        "orderId": 9,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-02-18:00"
+      },
+      {
+        "orderId": 10,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-01-18:00"
+      },
+      {
+        "orderId": 11,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-10-18:00"
+      },
+      {
+        "orderId": 12,
+        "title": "강남 케이크 제작 2",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_ONE",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-09-18:00"
+      },
+      {
+        "orderId": 13,
+        "title": "강남 케이크 제작 3",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_ONE",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-08-18:00"
+      },
+      {
+        "orderId": 14,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_TWO",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-07-18:00"
+      },
+      {
+        "orderId": 15,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_TWO",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-06-18:00"
+      },
+      {
+        "orderId": 16,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-05-18:00"
+      },
+      {
+        "orderId": 17,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-04-18:00"
+      },
+      {
+        "orderId": 18,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-03-18:00"
+      },
+      {
+        "orderId": 19,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-02-18:00"
+      },
+      {
+        "orderId": 20,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
+        "image": "/images/cake.png",
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-01-18:00"
+      }
+    ]
+  }
+}

--- a/components/Api/mock/letteringGangbok.json
+++ b/components/Api/mock/letteringGangbok.json
@@ -3,93 +3,103 @@
     "content": [
       {
         "orderId": 1,
-        "title": "축제케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "2호",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-03-05-18:00"
+        "orderStatus": "NEW",
+        "end_date": "2023-03-10-18:00"
       },
       {
         "orderId": 2,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 2",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-03-04-18:00"
+        "orderStatus": "NEW",
+        "end_date": "2023-03-09-18:00"
       },
       {
         "orderId": 3,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 3",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-03-03-18:00"
+        "orderStatus": "NEW",
+        "end_date": "2023-03-08-18:00"
       },
       {
         "orderId": 4,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-03-02-18:00"
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-07-18:00"
       },
       {
         "orderId": 5,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-03-01-18:00"
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-06-18:00"
       },
       {
         "orderId": 6,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-02-28-18:00"
+        "orderStatus": "NEW",
+        "end_date": "2023-03-05-18:00"
       },
       {
         "orderId": 7,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-02-27-18:00"
+        "orderStatus": "NEW",
+        "end_date": "2023-03-04-18:00"
       },
       {
         "orderId": 8,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-02-26-18:00"
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-03-18:00"
       },
       {
         "orderId": 9,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-02-25-18:00"
+        "orderStatus": "NEW",
+        "end_date": "2023-03-02-18:00"
       },
       {
         "orderId": 10,
-        "title": "생일케이크 만들어주세요",
+        "title": "강북 케이크 제작 1",
         "cakeCategory": "LETTERING",
-        "cakeSize": "1호",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
         "price": "13000",
-        "end_date": "2023-02-24-18:00"
+        "orderStatus": "NEW",
+        "end_date": "2023-03-01-18:00"
       }
     ]
   }

--- a/components/Api/mock/letteringGangbok.json
+++ b/components/Api/mock/letteringGangbok.json
@@ -2,164 +2,94 @@
   "data": {
     "content": [
       {
-        "postId": 1,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 1,
+        "title": "축제케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "2호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-03-05-18:00"
       },
       {
-        "postId": 2,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 2,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-03-04-18:00"
       },
       {
-        "postId": 3,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 3,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-03-03-18:00"
       },
       {
-        "postId": 4,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 4,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-03-02-18:00"
       },
       {
-        "postId": 5,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 5,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-03-01-18:00"
       },
       {
-        "postId": 6,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 6,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-02-28-18:00"
       },
       {
-        "postId": 7,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 7,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-02-27-18:00"
       },
       {
-        "postId": 8,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 8,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-02-26-18:00"
       },
       {
-        "postId": 9,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 9,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-02-25-18:00"
       },
       {
-        "postId": 10,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 10,
+        "title": "생일케이크 만들어주세요",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "1호",
         "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 11,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 12,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 13,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 14,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 15,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 16,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 17,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 18,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 19,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 20,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "end_date": "2023-02-24-18:00"
       }
     ]
   }

--- a/components/Api/mock/letteringGangnam.json
+++ b/components/Api/mock/letteringGangnam.json
@@ -2,164 +2,104 @@
   "data": {
     "content": [
       {
-        "postId": 1,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 1,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-10-18:00"
       },
       {
-        "postId": 2,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 2,
+        "title": "강남 케이크 제작 2",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-09-18:00"
       },
       {
-        "postId": 3,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 3,
+        "title": "강남 케이크 제작 3",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-08-18:00"
       },
       {
-        "postId": 4,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 4,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-07-18:00"
       },
       {
-        "postId": 5,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 5,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-06-18:00"
       },
       {
-        "postId": 6,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 6,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-05-18:00"
       },
       {
-        "postId": 7,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 7,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-04-18:00"
       },
       {
-        "postId": 8,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 8,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-03-18:00"
       },
       {
-        "postId": 9,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 9,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-02-18:00"
       },
       {
-        "postId": 10,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 10,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "LETTERING",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 11,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 12,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 13,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 14,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 15,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 16,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 17,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 18,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 19,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 20,
-        "category": "레터링",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-01-18:00"
       }
     ]
   }

--- a/components/Api/mock/marketDetail.json
+++ b/components/Api/mock/marketDetail.json
@@ -1,15 +1,17 @@
 {
   "data": {
-    "phoneNumber": "0212345678",
-    "city": "서울특별시",
-    "district": "강남구",
-    "detailAddress": "테헤란로",
-    "openTime": "09:00",
-    "endTime": "18:00",
-    "description": "맛있어요",
-    "marketName": "hey, cake",
+    "phoneNumber": "01012345678",
+    "address": {
+      "city": "서울",
+      "district": "노원구",
+      "detailAddress": "장미아파트"
+    },
+    "openTime": "09:00:00",
+    "endTime": "18:00:00",
+    "description": "설명",
+    "marketName": "성준이네",
     "businessNumber": "1234567890",
     "ownerName": "권성준",
-    "marketImage": "/images/prgms.png"
+    "marketImage": "url"
   }
 }

--- a/components/Api/mock/marketDetail.json
+++ b/components/Api/mock/marketDetail.json
@@ -1,0 +1,15 @@
+{
+  "data": {
+    "phoneNumber": "0212345678",
+    "city": "서울특별시",
+    "district": "강남구",
+    "detailAddress": "테헤란로",
+    "openTime": "09:00",
+    "endTime": "18:00",
+    "description": "맛있어요",
+    "marketName": "hey, cake",
+    "businessNumber": "1234567890",
+    "ownerName": "권성준",
+    "marketImage": "/images/prgms.png"
+  }
+}

--- a/components/Api/mock/marketList.json
+++ b/components/Api/mock/marketList.json
@@ -1,0 +1,114 @@
+{
+  "data": [
+    {
+      "enrollmentId": 1,
+      "businessNumber": "1111111",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 2,
+      "businessNumber": "2222222",
+      "address": "서울특별시",
+      "marketName": "프그케이크",
+      "phoneNumber": "01022222222",
+      "ownerName": "권성준",
+      "status": "waited",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 3,
+      "businessNumber": "3333333",
+      "address": "서울특별시",
+      "marketName": "서울케이크",
+      "phoneNumber": "0103333333",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 4,
+      "businessNumber": "1234567890",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 5,
+      "businessNumber": "1234567890",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "waited",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 6,
+      "businessNumber": "1234567890",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 7,
+      "businessNumber": "1234567890",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 8,
+      "businessNumber": "1234567890",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 9,
+      "businessNumber": "1234567890",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    },
+    {
+      "enrollmentId": 10,
+      "businessNumber": "1234567890",
+      "address": "서울특별시",
+      "marketName": "hey, cake",
+      "phoneNumber": "0212345678",
+      "ownerName": "권성준",
+      "status": "approved",
+      "marketImage": "/images/prgms.png",
+      "createdAt": "2023-01-19 18:30:00"
+    }
+  ]
+}

--- a/components/Api/mock/photoGangbok.json
+++ b/components/Api/mock/photoGangbok.json
@@ -2,164 +2,104 @@
   "data": {
     "content": [
       {
-        "postId": 1,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코 - 강북데이터",
+        "orderId": 1,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-10-18:00"
       },
       {
-        "postId": 2,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 2,
+        "title": "강북 케이크 제작 2",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-09-18:00"
       },
       {
-        "postId": 3,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 3,
+        "title": "강북 케이크 제작 3",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-08-18:00"
       },
       {
-        "postId": 4,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 4,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-07-18:00"
       },
       {
-        "postId": 5,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 5,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-06-18:00"
       },
       {
-        "postId": 6,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 6,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-05-18:00"
       },
       {
-        "postId": 7,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 7,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-04-18:00"
       },
       {
-        "postId": 8,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 8,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-03-18:00"
       },
       {
-        "postId": 9,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 9,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-02-18:00"
       },
       {
-        "postId": 10,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 10,
+        "title": "강북 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 11,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 12,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 13,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 14,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 15,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 16,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 17,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 18,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 19,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 20,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-01-18:00"
       }
     ]
   }

--- a/components/Api/mock/photoGangnam.json
+++ b/components/Api/mock/photoGangnam.json
@@ -2,164 +2,104 @@
   "data": {
     "content": [
       {
-        "postId": 1,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코 - 강남데이터",
+        "orderId": 1,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-10-18:00"
       },
       {
-        "postId": 2,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 2,
+        "title": "강남 케이크 제작 2",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-09-18:00"
       },
       {
-        "postId": 3,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 3,
+        "title": "강남 케이크 제작 3",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_ONE",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-08-18:00"
       },
       {
-        "postId": 4,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 4,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-07-18:00"
       },
       {
-        "postId": 5,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 5,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "SIZE_TWO",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-06-18:00"
       },
       {
-        "postId": 6,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 6,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-05-18:00"
       },
       {
-        "postId": 7,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 7,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-04-18:00"
       },
       {
-        "postId": 8,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 8,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "RESERVED",
+        "end_date": "2023-03-03-18:00"
       },
       {
-        "postId": 9,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 9,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-02-18:00"
       },
       {
-        "postId": 10,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
+        "orderId": 10,
+        "title": "강남 케이크 제작 1",
+        "cakeCategory": "PHOTO",
+        "cakeSize": "MINI",
         "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 11,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 12,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 13,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 14,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 15,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 16,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 17,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 18,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 19,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
-      },
-      {
-        "postId": 20,
-        "category": "포토",
-        "size": "1호",
-        "flavor": "초코",
-        "image": "/images/cake.png",
-        "price": "130,000"
+        "price": "13000",
+        "orderStatus": "NEW",
+        "end_date": "2023-03-01-18:00"
       }
     ]
   }

--- a/components/Main/cakeItem.tsx
+++ b/components/Main/cakeItem.tsx
@@ -9,12 +9,18 @@ import {
 } from '@chakra-ui/react';
 import Image from 'next/image';
 
-export default function CakeItem({ ...props }) {
-  // eslint-disable-next-line react/prop-types
-  const isComplete = props.isCompleted;
+export default function CakeItem({
+  title,
+  category,
+  cakeSize,
+  image,
+  price,
+  status,
+  endDate,
+}: any) {
   return (
     <Card
-      bgImage={isComplete ? '/images/completedCake.png' : ''}
+      bgImage={status === 'RESERVED' ? '/images/completedCake.png' : ''}
       bgPosition="center"
     >
       <Card
@@ -25,26 +31,25 @@ export default function CakeItem({ ...props }) {
         variant="outline"
         alignItems="center"
         justifyContent="space-between"
-        opacity={isComplete ? '0.4' : '1'}
+        opacity={status === 'RESERVED' ? '0.4' : '1'}
       >
         <Box p={2} borderRadius="12px">
-          <Image width={100} height={100} src="/images/cake.png" alt="Cake" />
+          <Image width={100} height={100} src={image} alt="Cake" />
         </Box>
         <CardBody px={2}>
           <Flex padding={0} gap={1} flexDirection="column">
             <Flex align="center" gap={4} justifyContent="space-between">
+              <Text>{title}</Text>
+            </Flex>
+            <Divider borderColor="hey.main" />
+            <Flex align="center" gap={4} justifyContent="space-between">
               <Text color="hey.main">카테고리</Text>
-              <Text fontSize="sm">포토</Text>
+              <Text fontSize="sm">{category}</Text>
             </Flex>
             <Divider borderColor="hey.main" />
             <Flex align="center" gap={4} justifyContent="space-between">
               <Text color="hey.main">케익 크기</Text>
-              <Text fontSize="sm">1호</Text>
-            </Flex>
-            <Divider borderColor="hey.main" />
-            <Flex align="center" gap={4} justifyContent="space-between">
-              <Text color="hey.main">케익 맛</Text>
-              <Text fontSize="sm">초코</Text>
+              <Text fontSize="sm">{cakeSize}</Text>
             </Flex>
             <Divider borderColor="hey.main" />
           </Flex>
@@ -58,10 +63,10 @@ export default function CakeItem({ ...props }) {
           p={2}
         >
           <Badge bgColor="red.200" color="hey.red">
-            ~1 일
+            ~ {endDate}
           </Badge>
           <Badge bgColor="orange.100" colorScheme="red" color="hey.red">
-            ~ ₩ 130,000
+            ~ ₩ {price}
           </Badge>
         </Flex>
       </Card>

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -1,6 +1,20 @@
-import { Grid } from '@chakra-ui/react';
+import { Grid, Text } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
 
-export default function CakeList() {
+import getCakeList from '../Api/getCakeList';
+import CakeItem from './cakeItem';
+
+export default function CakeList({ category, location }: any) {
+  const { status, data } = useQuery(['gangnam-photo'], () =>
+    getCakeList({
+      location,
+      category,
+    })
+  );
+
+  if (status === 'loading') {
+    return <span>Loading...</span>;
+  }
   return (
     <Grid>
       <Text>{item.postId}</Text>
@@ -9,6 +23,13 @@ export default function CakeList() {
       <Text>{item.flavor}</Text>
       <Text>{item.image}</Text>
       <Text>{item.price}</Text>
+
+      <CakeItem />
+      <CakeItem />
+      <CakeItem isCompleted />
+      <CakeItem />
+      <CakeItem />
+      <CakeItem />
     </Grid>
   );
 }

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -5,25 +5,32 @@ import getCakeList from '../Api/getCakeList';
 import CakeItem from './cakeItem';
 
 export default function CakeList({ category, location }: any) {
-  const { status, data } = useQuery(['gangnam-photo'], () =>
-    getCakeList({
-      location,
-      category,
-    })
+  const { status, data } = useQuery(
+    ['전체 케이크 리스트', category, location],
+    () =>
+      getCakeList({
+        location,
+        category,
+      })
   );
 
   if (status === 'loading') {
     return <span>Loading...</span>;
   }
   return (
-    <Grid>
-      <Text>{item.postId}</Text>
-      <Text>{item.category}</Text>
-      <Text>{item.size}</Text>
-      <Text>{item.flavor}</Text>
-      <Text>{item.image}</Text>
-      <Text>{item.price}</Text>
-
+    <Grid padding={0} gap={4} flexDirection="column">
+      {data?.map((item: any) => (
+        <Grid>
+          <Text>{item.orderId}</Text>
+          <Text>{item.title}</Text>
+          <Text>{item.cakeCategory}</Text>
+          <Text>{item.cakeSize}</Text>
+          <Text>{item.image}</Text>
+          <Text>{item.price}</Text>
+          <Text>{item.orderStatus}</Text>
+          <Text>{item.end_date}</Text>
+        </Grid>
+      ))}
       <CakeItem />
       <CakeItem />
       <CakeItem isCompleted />

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 
 import getCakeList from '../Api/getCakeList';
 import CakeItem from './cakeItem';
+import CakeListSkeleton from './cakeListSkeleton';
 
 export default function CakeList({ category, location }: any) {
   const { status, data } = useQuery(
@@ -16,7 +17,7 @@ export default function CakeList({ category, location }: any) {
   );
 
   if (status === 'loading') {
-    return <span>Loading...</span>;
+    return <CakeListSkeleton />;
   }
 
   return (

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -1,0 +1,14 @@
+import { Grid } from '@chakra-ui/react';
+
+export default function CakeList() {
+  return (
+    <Grid>
+      <Text>{item.postId}</Text>
+      <Text>{item.category}</Text>
+      <Text>{item.size}</Text>
+      <Text>{item.flavor}</Text>
+      <Text>{item.image}</Text>
+      <Text>{item.price}</Text>
+    </Grid>
+  );
+}

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -1,5 +1,6 @@
 import { Grid } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
 
 import getCakeList from '../Api/getCakeList';
 import CakeItem from './cakeItem';
@@ -21,15 +22,18 @@ export default function CakeList({ category, location }: any) {
   return (
     <Grid padding={0} gap={4} flexDirection="column">
       {data?.map((item: any) => (
-        <CakeItem
-          title={item.title}
-          category={item.cakeCategory}
-          cakeSize={item.cakeSize}
-          image={item.image}
-          price={item.price}
-          status={item.orderStatus}
-          endDate={item.end_date}
-        />
+        <Link href={`/orderlist/${item.orderId}`}>
+          <CakeItem
+            orderId={item.orderId}
+            title={item.title}
+            category={item.cakeCategory}
+            cakeSize={item.cakeSize}
+            image={item.image}
+            price={item.price}
+            status={item.orderStatus}
+            endDate={item.end_date}
+          />
+        </Link>
       ))}
     </Grid>
   );

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -1,4 +1,4 @@
-import { Grid, Text } from '@chakra-ui/react';
+import { Grid } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 
 import getCakeList from '../Api/getCakeList';

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -17,26 +17,20 @@ export default function CakeList({ category, location }: any) {
   if (status === 'loading') {
     return <span>Loading...</span>;
   }
+
   return (
     <Grid padding={0} gap={4} flexDirection="column">
       {data?.map((item: any) => (
-        <Grid>
-          <Text>{item.orderId}</Text>
-          <Text>{item.title}</Text>
-          <Text>{item.cakeCategory}</Text>
-          <Text>{item.cakeSize}</Text>
-          <Text>{item.image}</Text>
-          <Text>{item.price}</Text>
-          <Text>{item.orderStatus}</Text>
-          <Text>{item.end_date}</Text>
-        </Grid>
+        <CakeItem
+          title={item.title}
+          category={item.cakeCategory}
+          cakeSize={item.cakeSize}
+          image={item.image}
+          price={item.price}
+          status={item.orderStatus}
+          endDate={item.end_date}
+        />
       ))}
-      <CakeItem />
-      <CakeItem />
-      <CakeItem isCompleted />
-      <CakeItem />
-      <CakeItem />
-      <CakeItem />
     </Grid>
   );
 }

--- a/components/Main/cakeList.tsx
+++ b/components/Main/cakeList.tsx
@@ -22,7 +22,7 @@ export default function CakeList({ category, location }: any) {
   return (
     <Grid padding={0} gap={4} flexDirection="column">
       {data?.map((item: any) => (
-        <Link href={`/orderlist/${item.orderId}`}>
+        <Link key={item.orderId} href={`/orderlist/${item.orderId}`}>
           <CakeItem
             orderId={item.orderId}
             title={item.title}

--- a/components/Main/cakeListSkeleton.tsx
+++ b/components/Main/cakeListSkeleton.tsx
@@ -1,0 +1,18 @@
+import { Grid, Skeleton } from '@chakra-ui/react';
+
+export default function CakeListSkeleton() {
+  return (
+    <Grid justifyItems="center" padding={0} gap={4} flexDirection="column">
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+      <Skeleton height="140px" />
+    </Grid>
+  );
+}

--- a/components/Main/cakeMain.tsx
+++ b/components/Main/cakeMain.tsx
@@ -1,40 +1,12 @@
-import {
-  Box,
-  Flex,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
-} from '@chakra-ui/react';
+import { Box, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
+import { useState } from 'react';
 
 import CakeList from './cakeList';
+import { TAB_TABLE } from './constants';
 import LocationSelectBox from './locationSelectBox';
-import { ICakeList } from './types';
 
 export default function CakeMain() {
-  // 이후 통신할 데이터 주소를 contents로 넣어서 활용
-  // Sprint 4 이후 작업
-  const DUMMY_DATA: ICakeList[] = [
-    {
-      label: '전체',
-    },
-    {
-      label: '포토',
-    },
-    {
-      label: '레터링',
-    },
-    {
-      label: '캐릭터 - 그림',
-    },
-    {
-      label: '캐릭터 - 입체',
-    },
-    {
-      label: '기타',
-    },
-  ];
+  const [location, setLocation] = useState('강남구');
 
   return (
     <Tabs colorScheme="heys">
@@ -47,8 +19,8 @@ export default function CakeMain() {
         }}
       >
         <TabList w="max-content" alignItems="center" h="60px" p={2}>
-          <LocationSelectBox />
-          {DUMMY_DATA.map((tab) => (
+          <LocationSelectBox location={location} setLocation={setLocation} />
+          {TAB_TABLE.map((tab) => (
             <Tab key={tab.label} h="60px">
               {tab.label}
             </Tab>
@@ -56,11 +28,9 @@ export default function CakeMain() {
         </TabList>
       </Box>
       <TabPanels>
-        {DUMMY_DATA.map((tab) => (
+        {TAB_TABLE.map((tab) => (
           <TabPanel p={3} key={tab.label}>
-            <Flex padding={0} gap={4} flexDirection="column">
-              <CakeList category={tab.label} location="gangnam" />
-            </Flex>
+            <CakeList category={tab.category} location={location} />
           </TabPanel>
         ))}
       </TabPanels>

--- a/components/Main/cakeMain.tsx
+++ b/components/Main/cakeMain.tsx
@@ -1,59 +1,38 @@
 import {
   Box,
   Flex,
-  Grid,
   Tab,
   TabList,
   TabPanel,
   TabPanels,
   Tabs,
-  Text,
 } from '@chakra-ui/react';
-import { useQuery } from '@tanstack/react-query';
 
-import getCakeList from '../Api/getCakeList';
-import CakeItem from './cakeItem';
+import CakeList from './cakeList';
 import LocationSelectBox from './locationSelectBox';
 import { ICakeList } from './types';
 
 export default function CakeMain() {
-  const { status, data } = useQuery(['gangnam-photo'], () =>
-    getCakeList({
-      location: 'gangnam',
-      category: 'photo',
-    })
-  );
-
-  if (status === 'loading') {
-    return <span>Loading...</span>;
-  }
-
   // 이후 통신할 데이터 주소를 contents로 넣어서 활용
   // Sprint 4 이후 작업
   const DUMMY_DATA: ICakeList[] = [
     {
       label: '전체',
-      content: 'DUMMY_CAKE_LIST_ALL',
     },
     {
       label: '포토',
-      content: 'DUMMY_CAKE_LIST_PHOTO',
     },
     {
       label: '레터링',
-      content: 'DUMMY_CAKE_LIST_LATTER',
     },
     {
       label: '캐릭터 - 그림',
-      content: 'DUMMY_CAKE_LIST_CHARACTER_PICTURE',
     },
     {
       label: '캐릭터 - 입체',
-      content: 'DUMMY_CAKE_LIST_CHARACTER_3D',
     },
     {
       label: '기타',
-      content: 'DUMMY_CAKE_LIST_ETC',
     },
   ];
 
@@ -78,24 +57,9 @@ export default function CakeMain() {
       </Box>
       <TabPanels>
         {DUMMY_DATA.map((tab) => (
-          <TabPanel p={3} key={tab.content}>
+          <TabPanel p={3} key={tab.label}>
             <Flex padding={0} gap={4} flexDirection="column">
-              {data.map((item: any) => (
-                <Grid>
-                  <Text>{item.postId}</Text>
-                  <Text>{item.category}</Text>
-                  <Text>{item.size}</Text>
-                  <Text>{item.flavor}</Text>
-                  <Text>{item.image}</Text>
-                  <Text>{item.price}</Text>
-                </Grid>
-              ))}
-              <CakeItem />
-              <CakeItem />
-              <CakeItem isCompleted />
-              <CakeItem />
-              <CakeItem />
-              <CakeItem />
+              <CakeList category={tab.label} location="gangnam" />
             </Flex>
           </TabPanel>
         ))}

--- a/components/Main/cakeMain.tsx
+++ b/components/Main/cakeMain.tsx
@@ -9,7 +9,7 @@ export default function CakeMain() {
   const [location, setLocation] = useState('강남구');
 
   return (
-    <Tabs colorScheme="heys">
+    <Tabs colorScheme="heys" isLazy>
       <Box
         overflow="scroll"
         sx={{

--- a/components/Main/constants.ts
+++ b/components/Main/constants.ts
@@ -1,0 +1,56 @@
+import { ICakeList } from './types';
+
+export const TAB_TABLE: ICakeList[] = [
+  {
+    label: '전체',
+    category: 'ALL',
+  },
+  {
+    label: '포토',
+    category: 'PHOTO',
+  },
+  {
+    label: '레터링',
+    category: 'LETTERING',
+  },
+  {
+    label: '캐릭터 - 그림',
+    category: 'CHARACTER_IMAGE',
+  },
+  {
+    label: '캐릭터 - 입체',
+    category: 'CHARACTER_MODEL',
+  },
+  {
+    label: '기타',
+    category: 'ETC',
+  },
+];
+
+export const SEOUL_AREA = [
+  '강남구',
+  '강동구',
+  '강북구',
+  '강서구',
+  '관악구',
+  '광진구',
+  '구로구',
+  '금천구',
+  '노원구',
+  '도봉구',
+  '동대문구',
+  '동작구',
+  '마포구',
+  '서대문구',
+  '서초구',
+  '성동구',
+  '성북구',
+  '송파구',
+  '양천구',
+  '영등포구',
+  '용산구',
+  '은평구',
+  '종로구',
+  '중구',
+  '중량',
+];

--- a/components/Main/locationSelectBox.tsx
+++ b/components/Main/locationSelectBox.tsx
@@ -9,41 +9,14 @@ import {
   Text,
   useDisclosure,
 } from '@chakra-ui/react';
-import { useState } from 'react';
 import { BiCurrentLocation } from 'react-icons/bi';
 
+import { SEOUL_AREA } from './constants';
 import LocationListItem from './locationListItem';
 
-export default function LocationSelectBox() {
+export default function LocationSelectBox({ location, setLocation }: any) {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [location, setLocation] = useState('강남구');
-  const SEOUL_AREA = [
-    '강남구',
-    '강동구',
-    '강북구',
-    '강서구',
-    '관악구',
-    '광진구',
-    '구로구',
-    '금천구',
-    '노원구',
-    '도봉구',
-    '동대문구',
-    '동작구',
-    '마포구',
-    '서대문구',
-    '서초구',
-    '성동구',
-    '성북구',
-    '송파구',
-    '양천구',
-    '영등포구',
-    '용산구',
-    '은평구',
-    '종로구',
-    '중구',
-    '중량구',
-  ];
+
   return (
     <>
       <Flex

--- a/components/Main/types.ts
+++ b/components/Main/types.ts
@@ -1,6 +1,5 @@
 export interface ICakeList {
   label: string;
-  content: string;
 }
 
 export interface ILocationListItem {

--- a/components/Main/types.ts
+++ b/components/Main/types.ts
@@ -1,5 +1,6 @@
 export interface ICakeList {
   label: string;
+  category: string;
 }
 
 export interface ILocationListItem {

--- a/components/Market/marketProfile.tsx
+++ b/components/Market/marketProfile.tsx
@@ -1,6 +1,8 @@
 import { Container, Divider, Flex, Text } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
 import Image from 'next/image';
 
+import getMarketDetail from '../Api/getMarketDetail';
 import {
   MarketAddressIcon,
   MarketInfoIcon,
@@ -10,6 +12,14 @@ import {
 import MarketTitle from './marketTitle';
 
 export default function MarketProfile() {
+  const { status, data } = useQuery(['prgms'], () => getMarketDetail());
+
+  if (status === 'loading') {
+    return <span>Loading...</span>;
+  }
+
+  console.log(data);
+
   return (
     <>
       <MarketTitle />

--- a/pages/api/enrollments/[id].tsx
+++ b/pages/api/enrollments/[id].tsx
@@ -1,0 +1,11 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import marketDetail from '@/components/Api/mock/marketDetail.json';
+
+export default async function getMarketDetail(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  // enrollmentsId : request.query
+  return response.status(200).end(JSON.stringify(marketDetail));
+}

--- a/pages/api/enrollments/[id].tsx
+++ b/pages/api/enrollments/[id].tsx
@@ -6,6 +6,6 @@ export default async function getMarketDetail(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
-  // enrollmentsId : request.query
+  // enrollmentsId : request.query (632463)
   return response.status(200).end(JSON.stringify(marketDetail));
 }

--- a/pages/api/enrollments/index.tsx
+++ b/pages/api/enrollments/index.tsx
@@ -1,0 +1,10 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+import marketList from '@/components/Api/mock/marketList.json';
+
+export default async function getMarketList(
+  request: NextApiRequest,
+  response: NextApiResponse
+) {
+  return response.status(200).end(JSON.stringify(marketList));
+}

--- a/pages/api/orders.tsx
+++ b/pages/api/orders.tsx
@@ -10,28 +10,27 @@ export default async function getCakeList(
   response: NextApiResponse
 ) {
   const { location, category } = request.body;
-  const cursur = request.query.id;
 
-  if (category === 'photo') {
-    if (location === 'gangnam') {
+  if (category === 'PHOTO') {
+    if (location === '강남구') {
       return response
         .status(200)
         .end(JSON.stringify(photoGangnam.data.content));
     }
-    if (location === 'gangbok') {
+    if (location === '강북구') {
       return response
         .status(200)
         .end(JSON.stringify(photoGangbok.data.content));
     }
   }
 
-  if (category === 'lettering') {
-    if (location === 'gangnam') {
+  if (category === 'LETTERING') {
+    if (location === '강남구') {
       return response
         .status(200)
         .end(JSON.stringify(letteringGangnam.data.content));
     }
-    if (location === 'gangbok') {
+    if (location === '강북구') {
       return response
         .status(200)
         .end(JSON.stringify(letteringGangbok.data.content));

--- a/pages/api/orders.tsx
+++ b/pages/api/orders.tsx
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 
+import allGangnam from '@/components/Api/mock/allGangnam.json';
 import letteringGangbok from '@/components/Api/mock/letteringGangbok.json';
 import letteringGangnam from '@/components/Api/mock/letteringGangnam.json';
 import photoGangbok from '@/components/Api/mock/photoGangbok.json';
@@ -10,6 +11,9 @@ export default async function getCakeList(
   response: NextApiResponse
 ) {
   const { location, category } = request.body;
+  if (category === 'ALL') {
+    return response.status(200).end(JSON.stringify(allGangnam.data.content));
+  }
 
   if (category === 'PHOTO') {
     if (location === '강남구') {

--- a/pages/api/orders.tsx
+++ b/pages/api/orders.tsx
@@ -40,5 +40,7 @@ export default async function getCakeList(
         .end(JSON.stringify(letteringGangbok.data.content));
     }
   }
-  return response.status(500).end('err');
+  // return response.status(500).end('err');
+  // 임시로 예외 사항일 때 200으로 기본데이터를 쏘게 변경
+  return response.status(200).end(JSON.stringify(allGangnam.data.content));
 }

--- a/pages/api/orders.tsx
+++ b/pages/api/orders.tsx
@@ -10,6 +10,8 @@ export default async function getCakeList(
   response: NextApiResponse
 ) {
   const { location, category } = request.body;
+  const cursur = request.query.id;
+
   if (category === 'photo') {
     if (location === 'gangnam') {
       return response
@@ -17,16 +19,22 @@ export default async function getCakeList(
         .end(JSON.stringify(photoGangnam.data.content));
     }
     if (location === 'gangbok') {
-      return response.status(200).end(JSON.stringify(photoGangbok));
+      return response
+        .status(200)
+        .end(JSON.stringify(photoGangbok.data.content));
     }
   }
 
   if (category === 'lettering') {
     if (location === 'gangnam') {
-      return response.status(200).end(JSON.stringify(letteringGangnam));
+      return response
+        .status(200)
+        .end(JSON.stringify(letteringGangnam.data.content));
     }
     if (location === 'gangbok') {
-      return response.status(200).end(JSON.stringify(letteringGangbok));
+      return response
+        .status(200)
+        .end(JSON.stringify(letteringGangbok.data.content));
     }
   }
   return response.status(500).end('err');


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #37 

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
### Mock 데이터와 연동
- [x]   React-query + Axios로 서버 통신하기
- [x]  하단 케이크 리스트 탭에서 각자의 지역 / 항목에 맞는 케이크 리스트를 보여준다
- [x]  케이크 리스트를 눌러서 상세 페이지 조회 (order/xxx)로 이동한다

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome_XJmjoM7KUl](https://user-images.githubusercontent.com/97251710/221590757-115aefa0-60d0-44d8-8f45-754db6bbde69.gif)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
임시 데이터로 구성되있습니다. 차후 백엔드 서버 활성화 후 API_END_POINT로 연결할 예정입니다.
