### PR TITLE
feat: 관리자 페이지와 Mock API를 연동한다

### DIFF
--- a/components/Admin/index.tsx
+++ b/components/Admin/index.tsx
@@ -1,19 +1,35 @@
-import { Container, Grid } from '@chakra-ui/react';
+import {
+  Container,
+  Grid,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+} from '@chakra-ui/react';
 
 import MarketItem from './marketItem';
+import MarketList from './marketList';
 
 export default function Admin() {
   return (
-    <Container mt={4}>
-      <Grid gap={4}>
-        <MarketItem />
-        <MarketItem />
-        <MarketItem />
-        <MarketItem />
-        <MarketItem />
-        <MarketItem />
-        <MarketItem />
-      </Grid>
-    </Container>
+    <Tabs colorScheme="heys" w="max-content" isLazy>
+      <TabList alignItems="center" h="60px" p={2}>
+        <Tab w="50%" h="60px">
+          승인 목록
+        </Tab>
+        <Tab w="50%" h="60px">
+          거절 목록
+        </Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <MarketList category={null} />
+        </TabPanel>
+        <TabPanel>
+          <MarketList category="deleted" />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
   );
 }

--- a/components/Admin/index.tsx
+++ b/components/Admin/index.tsx
@@ -1,19 +1,10 @@
-import {
-  Container,
-  Grid,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
-} from '@chakra-ui/react';
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
 
-import MarketItem from './marketItem';
 import MarketList from './marketList';
 
 export default function Admin() {
   return (
-    <Tabs colorScheme="heys" w="max-content" isLazy>
+    <Tabs colorScheme="heys" isLazy>
       <TabList alignItems="center" h="60px" p={2}>
         <Tab w="50%" h="60px">
           승인 목록

--- a/components/Admin/marketItem.tsx
+++ b/components/Admin/marketItem.tsx
@@ -17,9 +17,7 @@ export default function MarketItem({
   businessNumber,
   status,
 }: any) {
-  const [marketSwitch, onMarketSwitch] = useState(false);
-  if (status === 'approve') onMarketSwitch(true);
-
+  const [marketSwitch, setMarketSwitch] = useState(false);
   return (
     <Card
       borderColor="hey.sub"
@@ -36,7 +34,7 @@ export default function MarketItem({
       <CardBody px={2}>
         <Flex padding={0} gap={3} flexDirection="column">
           <Flex align="center" gap={4} justifyContent="space-between">
-            <Text fontSize="lg" fontWeight="700" color="hey.main">
+            <Text fontWeight="700" color="hey.main">
               업체명
             </Text>
             <Flex gap={2} alignItems="center">
@@ -50,8 +48,8 @@ export default function MarketItem({
             <Flex gap={2}>
               <Text>승인</Text>
               <Switch
-                isChecked
-                onChange={() => onMarketSwitch(!marketSwitch)}
+                isChecked={status === 'approved'}
+                onChange={() => setMarketSwitch(!marketSwitch)}
               />
             </Flex>
           </Flex>

--- a/components/Admin/marketItem.tsx
+++ b/components/Admin/marketItem.tsx
@@ -9,7 +9,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export default function MarketItem({
   marketImage,
@@ -18,6 +18,17 @@ export default function MarketItem({
   status,
 }: any) {
   const [marketSwitch, setMarketSwitch] = useState(false);
+
+  const onSwitchHandler = () => {
+    setMarketSwitch(!marketSwitch);
+  };
+
+  useEffect(() => {
+    if (status === 'approved') {
+      onSwitchHandler();
+    }
+  }, [status]);
+
   return (
     <Card
       borderColor="hey.sub"
@@ -34,24 +45,13 @@ export default function MarketItem({
       <CardBody px={2}>
         <Flex padding={0} gap={3} flexDirection="column">
           <Flex align="center" gap={4} justifyContent="space-between">
-            <Text fontWeight="700" color="hey.main">
-              업체명
-            </Text>
-            <Flex gap={2} alignItems="center">
-              <Text>{marketName}</Text>
-              <CloseButton variant="custom" />
-            </Flex>
+            <Text>{marketName}</Text>
+            <CloseButton bgColor="red.500" color="white" />
           </Flex>
           <Divider borderColor="hey.main" />
           <Flex align="center" gap={4} justifyContent="space-between">
             <Text fontWeight="600">{businessNumber}</Text>
-            <Flex gap={2}>
-              <Text>승인</Text>
-              <Switch
-                isChecked={status === 'approved'}
-                onChange={() => setMarketSwitch(!marketSwitch)}
-              />
-            </Flex>
+            <Switch isChecked={marketSwitch} onChange={onSwitchHandler} />
           </Flex>
         </Flex>
       </CardBody>

--- a/components/Admin/marketItem.tsx
+++ b/components/Admin/marketItem.tsx
@@ -5,13 +5,16 @@ import {
   CloseButton,
   Divider,
   Flex,
+  Grid,
   Switch,
   Text,
 } from '@chakra-ui/react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 export default function MarketItem({
+  enrollmentId,
   marketImage,
   marketName,
   businessNumber,
@@ -31,6 +34,7 @@ export default function MarketItem({
 
   return (
     <Card
+      key={enrollmentId}
       borderColor="hey.sub"
       borderWidth="2px"
       bgColor="orange.50"
@@ -40,21 +44,29 @@ export default function MarketItem({
       justifyContent="space-between"
     >
       <Box p={2} borderRadius="12px">
-        <Image width={100} height={100} src={marketImage} alt="Cake" />
+        <Link key={enrollmentId} href={`/market/${enrollmentId}`}>
+          <Image width={100} height={100} src={marketImage} alt="Cake" />
+        </Link>
       </Box>
       <CardBody px={2}>
-        <Flex padding={0} gap={3} flexDirection="column">
-          <Flex align="center" gap={4} justifyContent="space-between">
-            <Text>{marketName}</Text>
-            <CloseButton bgColor="red.500" color="white" />
+        <Link key={enrollmentId} href={`/market/${enrollmentId}`}>
+          <Flex padding={0} gap={3} flexDirection="column">
+            <Flex align="center" gap={4} justifyContent="space-between">
+              <Text>{marketName}</Text>
+            </Flex>
+            <Divider borderColor="hey.main" />
+            <Flex align="center" gap={4} justifyContent="space-between">
+              <Text fontWeight="600">{businessNumber}</Text>
+            </Flex>
           </Flex>
-          <Divider borderColor="hey.main" />
-          <Flex align="center" gap={4} justifyContent="space-between">
-            <Text fontWeight="600">{businessNumber}</Text>
-            <Switch isChecked={marketSwitch} onChange={onSwitchHandler} />
-          </Flex>
-        </Flex>
+        </Link>
       </CardBody>
+      <Box px={2}>
+        <Grid padding={0} gap={10}>
+          <CloseButton bgColor="red.500" color="white" />
+          <Switch isChecked={marketSwitch} onChange={onSwitchHandler} />
+        </Grid>
+      </Box>
     </Card>
   );
 }

--- a/components/Admin/marketItem.tsx
+++ b/components/Admin/marketItem.tsx
@@ -2,6 +2,7 @@ import {
   Box,
   Card,
   CardBody,
+  CloseButton,
   Divider,
   Flex,
   Switch,
@@ -10,9 +11,14 @@ import {
 import Image from 'next/image';
 import { useState } from 'react';
 
-export default function MarketItem() {
+export default function MarketItem({
+  marketImage,
+  marketName,
+  businessNumber,
+  status,
+}: any) {
   const [marketSwitch, onMarketSwitch] = useState(false);
-  /* console.log(marketSwitch); */
+  if (status === 'approve') onMarketSwitch(true);
 
   return (
     <Card
@@ -25,20 +31,29 @@ export default function MarketItem() {
       justifyContent="space-between"
     >
       <Box p={2} borderRadius="12px">
-        <Image width={100} height={100} src="/images/prgms.png" alt="Cake" />
+        <Image width={100} height={100} src={marketImage} alt="Cake" />
       </Box>
       <CardBody px={2}>
-        <Flex padding={0} gap={2} flexDirection="column">
+        <Flex padding={0} gap={3} flexDirection="column">
           <Flex align="center" gap={4} justifyContent="space-between">
             <Text fontSize="lg" fontWeight="700" color="hey.main">
               업체명
             </Text>
-            <Text>프그케이크</Text>
+            <Flex gap={2} alignItems="center">
+              <Text>{marketName}</Text>
+              <CloseButton variant="custom" />
+            </Flex>
           </Flex>
           <Divider borderColor="hey.main" />
           <Flex align="center" gap={4} justifyContent="space-between">
-            <Text fontWeight="600">412-23-13145</Text>
-            <Switch onChange={() => onMarketSwitch(!marketSwitch)} />
+            <Text fontWeight="600">{businessNumber}</Text>
+            <Flex gap={2}>
+              <Text>승인</Text>
+              <Switch
+                isChecked
+                onChange={() => onMarketSwitch(!marketSwitch)}
+              />
+            </Flex>
           </Flex>
         </Flex>
       </CardBody>

--- a/components/Admin/marketItem.tsx
+++ b/components/Admin/marketItem.tsx
@@ -34,7 +34,6 @@ export default function MarketItem({
 
   return (
     <Card
-      key={enrollmentId}
       borderColor="hey.sub"
       borderWidth="2px"
       bgColor="orange.50"

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -1,4 +1,4 @@
-import { Container, Grid } from '@chakra-ui/react';
+import { Grid } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 
@@ -15,6 +15,8 @@ export default function MarketList({ category }: any) {
     return <CakeListSkeleton />;
   }
 
+  /* <Link key={item.enrollmentId} href={`/market/${item.enrollmentId}`}></Link> */
+
   return (
     <Grid gap={4}>
       {data?.map((item: any) => (
@@ -24,8 +26,6 @@ export default function MarketList({ category }: any) {
           businessNumber={item.businessNumber}
           status={item.status}
         />
-        /*       <Link key={item.enrollmentId} href={`/market/${item.enrollmentId}`}></Link>
-          </Link> */
       ))}
     </Grid>
   );

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -1,6 +1,5 @@
-import { Grid } from '@chakra-ui/react';
+import { Box, Grid } from '@chakra-ui/react';
 import { useQuery } from '@tanstack/react-query';
-import Link from 'next/link';
 
 import getMarketList from '../Api/getMarketList';
 import CakeListSkeleton from '../Main/cakeListSkeleton';
@@ -15,18 +14,18 @@ export default function MarketList({ category }: any) {
     return <CakeListSkeleton />;
   }
 
-  /* <Link key={item.enrollmentId} href={`/market/${item.enrollmentId}`}></Link> */
-
   return (
     <Grid gap={4}>
       {data?.map((item: any) => (
-        <MarketItem
-          enrollmentId={item.enrollmentId}
-          marketImage={item.marketImage}
-          marketName={item.marketName}
-          businessNumber={item.businessNumber}
-          status={item.status}
-        />
+        <Box key={item.enrollmentId}>
+          <MarketItem
+            enrollmentId={item.enrollmentId}
+            marketImage={item.marketImage}
+            marketName={item.marketName}
+            businessNumber={item.businessNumber}
+            status={item.status}
+          />
+        </Box>
       ))}
     </Grid>
   );

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -1,0 +1,34 @@
+import { Container, Grid } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
+
+import getMarketList from '../Api/getMarketList';
+import CakeListSkeleton from '../Main/cakeListSkeleton';
+import MarketItem from './marketItem';
+
+export default function MarketList({ category }: any) {
+  const { status, data } = useQuery(['승인 마켓 리스트', category], () =>
+    getMarketList()
+  );
+
+  if (status === 'loading') {
+    return <CakeListSkeleton />;
+  }
+
+  return (
+    <Container mt={4}>
+      <Grid gap={4}>
+        {data?.map((item: any) => (
+          <MarketItem
+            marketImage={item.marketImage}
+            marketName={item.marketName}
+            businessNumber={item.businessNumber}
+            status={item.status}
+          />
+          /*       <Link key={item.enrollmentId} href={`/market/${item.enrollmentId}`}></Link>
+          </Link> */
+        ))}
+      </Grid>
+    </Container>
+  );
+}

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -16,19 +16,17 @@ export default function MarketList({ category }: any) {
   }
 
   return (
-    <Container mt={4}>
-      <Grid gap={4}>
-        {data?.map((item: any) => (
-          <MarketItem
-            marketImage={item.marketImage}
-            marketName={item.marketName}
-            businessNumber={item.businessNumber}
-            status={item.status}
-          />
-          /*       <Link key={item.enrollmentId} href={`/market/${item.enrollmentId}`}></Link>
+    <Grid gap={4}>
+      {data?.map((item: any) => (
+        <MarketItem
+          marketImage={item.marketImage}
+          marketName={item.marketName}
+          businessNumber={item.businessNumber}
+          status={item.status}
+        />
+        /*       <Link key={item.enrollmentId} href={`/market/${item.enrollmentId}`}></Link>
           </Link> */
-        ))}
-      </Grid>
-    </Container>
+      ))}
+    </Grid>
   );
 }

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -21,6 +21,7 @@ export default function MarketList({ category }: any) {
     <Grid gap={4}>
       {data?.map((item: any) => (
         <MarketItem
+          enrollmentId={item.enrollmentId}
           marketImage={item.marketImage}
           marketName={item.marketName}
           businessNumber={item.businessNumber}

--- a/components/Api/mock/marketList.json
+++ b/components/Api/mock/marketList.json
@@ -8,7 +8,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -19,7 +19,7 @@
       "phoneNumber": "01022222222",
       "ownerName": "권성준",
       "status": "waited",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -30,7 +30,7 @@
       "phoneNumber": "0103333333",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -41,7 +41,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -52,7 +52,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "waited",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -63,7 +63,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -74,7 +74,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -85,7 +85,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -96,7 +96,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     },
     {
@@ -107,7 +107,7 @@
       "phoneNumber": "0212345678",
       "ownerName": "권성준",
       "status": "approved",
-      "marketImage": "/images/prgms.png",
+      "marketImage": "https://i.imgur.com/agjDBqa.png",
       "createdAt": "2023-01-19 18:30:00"
     }
   ]

--- a/pages/api/enrollments/index.tsx
+++ b/pages/api/enrollments/index.tsx
@@ -6,5 +6,5 @@ export default async function getMarketList(
   request: NextApiRequest,
   response: NextApiResponse
 ) {
-  return response.status(200).end(JSON.stringify(marketList));
+  return response.status(200).end(JSON.stringify(marketList.data));
 }


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #45

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->
## 관리자 페이지 (/admin , /admin/login)과 api를 연결한다

- [ ] /admin 페이지를 통해 승인업체 대기업체 목록을 볼 수 있다
- [ ] /admin 페이지를 통해 삭제한 업체를 볼 수 있다
- [ ] /admin의 토글을 사용해 승인 대기 상태로 변경할 수 있다
- [ ] /admin의 삭제 버튼을 누르면 삭제 업체로 넘어간다


## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome_apf0cv6iER](https://user-images.githubusercontent.com/97251710/221772907-26bfc7d0-67d3-464a-a0a8-26a21c3eeb59.gif)


## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

삭제 항목의 카드 UI와 통신은 추가 기능으로서 추가될 예정입니다

(불가능하면 비활성화로 변경 예정입니다)
