### PR TITLE
fix: 각 페이지의 통신 실패시 에러대응

### DIFF
--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -20,7 +20,6 @@ export default function MarketList({ category }: IMarketList) {
     }
   );
 
-  console.log(status);
 
   useEffect(() => {
     if (inView) fetchNextPage();

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -30,6 +30,13 @@ export default function MarketList({ category }: IMarketList) {
     return <AdminListSkeleton />;
   }
 
+  if (status === 'error') {
+    alert(
+      '마켓신청 리스트 조회에 실패했습니다. (새로고침 or 메인페이지 이동버튼)'
+    );
+    return router.back();
+  }
+
   return (
     <>
       <Grid gap={0}>

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -1,17 +1,16 @@
 import { CircularProgress, Grid, Stack } from '@chakra-ui/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { getMarketList } from '../Api/Market';
+import ApiErrorAlert from '../Shared/apiErrorAlert';
 import AdminListSkeleton from './adminLIstSkeleton';
 import MarketItem from './marketItem';
 import { IMarketItem, IMarketList } from './types';
 
 export default function MarketList({ category }: IMarketList) {
   const { ref, inView } = useInView();
-  const router = useRouter();
   const { data, status, fetchNextPage, isFetchingNextPage } = useInfiniteQuery(
     ['승인 마켓 리스트', category],
     ({ pageParam = '' }) => getMarketList({ cursor: pageParam, category }),
@@ -21,27 +20,26 @@ export default function MarketList({ category }: IMarketList) {
     }
   );
 
+  console.log(status);
+
   useEffect(() => {
     if (inView) fetchNextPage();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [inView]);
 
-  if (status === 'loading' || !router.isReady) {
+  if (status === 'loading') {
     return <AdminListSkeleton />;
   }
 
   if (status === 'error') {
-    alert(
-      '마켓신청 리스트 조회에 실패했습니다. (새로고침 or 메인페이지 이동버튼)'
-    );
-    return router.back();
+    return <ApiErrorAlert />;
   }
 
   return (
     <>
       <Grid gap={0}>
         {data?.pages.map((page) =>
-          page.enrollments.map((item: IMarketItem) => (
+          page?.enrollments.map((item: IMarketItem) => (
             <Stack key={item.enrollmentId}>
               <MarketItem
                 phoneNumber={item.phoneNumber}

--- a/components/Admin/marketList.tsx
+++ b/components/Admin/marketList.tsx
@@ -20,7 +20,6 @@ export default function MarketList({ category }: IMarketList) {
     }
   );
 
-
   useEffect(() => {
     if (inView) fetchNextPage();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/components/Api/Main.ts
+++ b/components/Api/Main.ts
@@ -15,8 +15,8 @@ export default async function getCakeList({
     if (response.status === 200) {
       return response.data;
     }
-  } catch (error) {
-    return console.error(error);
+  } catch (error: any) {
+    throw new Error(error);
   }
-  return console.error('케이크 리스트를 받아오는데 에러가 발생했습니다');
+  throw new Error('케이크 리스트를 받아오는데 에러가 발생했습니다');
 }

--- a/components/Api/Market.ts
+++ b/components/Api/Market.ts
@@ -10,10 +10,10 @@ export async function getMarketDetail({ enrollmentId }: IgetMarketDetail) {
     if (response.status === 200) {
       return response.data;
     }
-  } catch (error) {
-    return console.error(error);
+  } catch (error: any) {
+    throw new Error(error);
   }
-  return console.error('마켓 상세 정보를 받아오는데 에러가 발생했습니다');
+  throw new Error('마켓 상세 정보를 받아오는데 에러가 발생했습니다');
 }
 
 export async function getMarketList({ cursor, category }: IgetMarketList) {
@@ -25,10 +25,10 @@ export async function getMarketList({ cursor, category }: IgetMarketList) {
     if (response.status === 200) {
       return response.data;
     }
-  } catch (error) {
-    return console.error(error);
+  } catch (error: any) {
+    throw new Error(error);
   }
-  return console.error('마켓 승인 리스트를 받아오는데 에러가 발생했습니다');
+  throw new Error('마켓 승인 리스트를 받아오는데 에러가 발생했습니다');
 }
 
 export async function patchMarketStatus({
@@ -43,8 +43,8 @@ export async function patchMarketStatus({
     if (response.status === 200) {
       return response.data;
     }
-  } catch (error) {
-    return console.error(error);
+  } catch (error: any) {
+    throw new Error(error);
   }
-  return console.error('마켓 상태 변경에 문제가 발생했습니다');
+  throw new Error('마켓 상태 변경에 문제가 발생했습니다');
 }

--- a/components/Api/index.tsx
+++ b/components/Api/index.tsx
@@ -19,7 +19,7 @@ const options = {
     Accept: '*/*',
     'Content-Type': 'application/json',
   },
-  timeout: 10000,
+  timeout: 5000,
 };
 
 export const internalApi = setInterceptor(

--- a/components/Main/cake/cakeList.tsx
+++ b/components/Main/cake/cakeList.tsx
@@ -1,6 +1,7 @@
 import { Box, CircularProgress, Grid, useToast } from '@chakra-ui/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
@@ -12,6 +13,7 @@ import CakeListSkeleton from './cakeListSkeleton';
 export default function CakeList({ category, location }: any) {
   const toast = useToast();
   const { ref, inView } = useInView();
+  const router = useRouter();
   const { data, status, fetchNextPage, isFetchingNextPage } = useInfiniteQuery(
     ['전체 케이크 리스트', category, location],
     ({ pageParam = '' }) =>
@@ -58,6 +60,11 @@ export default function CakeList({ category, location }: any) {
 
   if (status === 'loading') {
     return <CakeListSkeleton />;
+  }
+
+  if (status === 'error') {
+    alert('메인페이지 조회에 실패했습니다. (새로고침)');
+    return router.back();
   }
 
   return (

--- a/components/Main/cake/cakeList.tsx
+++ b/components/Main/cake/cakeList.tsx
@@ -1,9 +1,10 @@
 import { Box, CircularProgress, Grid, useToast } from '@chakra-ui/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import Link from 'next/link';
-import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
+
+import ApiErrorAlert from '@/components/Shared/apiErrorAlert';
 
 import getCakeList from '../../Api/Main';
 import { ICakeItemData } from '../types';
@@ -13,7 +14,6 @@ import CakeListSkeleton from './cakeListSkeleton';
 export default function CakeList({ category, location }: any) {
   const toast = useToast();
   const { ref, inView } = useInView();
-  const router = useRouter();
   const { data, status, fetchNextPage, isFetchingNextPage } = useInfiniteQuery(
     ['전체 케이크 리스트', category, location],
     ({ pageParam = '' }) =>
@@ -63,8 +63,7 @@ export default function CakeList({ category, location }: any) {
   }
 
   if (status === 'error') {
-    alert('메인페이지 조회에 실패했습니다. (새로고침)');
-    return router.back();
+    return <ApiErrorAlert />;
   }
 
   return (

--- a/components/Market/marketProfile.tsx
+++ b/components/Market/marketProfile.tsx
@@ -23,6 +23,11 @@ export default function MarketProfile() {
     return <MarketProfileSkeleton />;
   }
 
+  if (status === 'error') {
+    alert('업주 정보 조회에 실패했습니다');
+    return router.back();
+  }
+
   const address = `${data.marketAddress.city} ${data.marketAddress.district} ${data.marketAddress.detailAddress}`;
   const openingHours = `${data.openTime} ~ ${data.endTime}`;
 

--- a/components/Market/marketProfile.tsx
+++ b/components/Market/marketProfile.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 import { getMarketDetail } from '../Api/Market';
+import ApiErrorAlert from '../Shared/apiErrorAlert';
 import {
   MarketAddressIcon,
   MarketInfoIcon,
@@ -24,8 +25,7 @@ export default function MarketProfile() {
   }
 
   if (status === 'error') {
-    alert('업주 정보 조회에 실패했습니다');
-    return router.back();
+    return <ApiErrorAlert />;
   }
 
   const address = `${data.marketAddress.city} ${data.marketAddress.district} ${data.marketAddress.detailAddress}`;

--- a/components/Shared/apiErrorAlert.tsx
+++ b/components/Shared/apiErrorAlert.tsx
@@ -1,3 +1,52 @@
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { useEffect, useRef } from 'react';
+
 export default function ApiErrorAlert() {
-  return <div>에러 발생</div>;
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const router = useRouter();
+
+  useEffect(onOpen, []);
+
+  return (
+    <AlertDialog
+      leastDestructiveRef={cancelRef}
+      onClose={onClose}
+      isOpen={isOpen}
+      isCentered
+    >
+      <AlertDialogOverlay />
+      <AlertDialogContent m={4}>
+        <AlertDialogHeader>페이지에 에러가 발생했습니다</AlertDialogHeader>
+        <AlertDialogBody>관리자에게 문의해주세요</AlertDialogBody>
+        <AlertDialogFooter>
+          <Button
+            colorScheme="green"
+            color="white"
+            onClick={() => router.reload()}
+          >
+            새로고침
+          </Button>
+          <Button
+            colorScheme="orange"
+            color="white"
+            onClick={() => router.replace('/main')}
+            ml={3}
+          >
+            메인페이지로 이동
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }

--- a/components/Shared/apiErrorAlert.tsx
+++ b/components/Shared/apiErrorAlert.tsx
@@ -1,0 +1,3 @@
+export default function ApiErrorAlert() {
+  return <div>에러 발생</div>;
+}

--- a/components/Shared/apiErrorAlert.tsx
+++ b/components/Shared/apiErrorAlert.tsx
@@ -16,7 +16,7 @@ export default function ApiErrorAlert() {
   const cancelRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
 
-  useEffect(onOpen, []);
+  useEffect(onOpen, [onOpen]);
 
   return (
     <AlertDialog


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #119

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

- [x] 메인 페이지의 통신 실패 오류에 대응한다
- [x] 마켓 상세 페이지의 통신 실패 오류에 대응한다
- [x] 관리자 페이지의 통신 실패 오류에 대응한다

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome_WH4TEJIOTk](https://user-images.githubusercontent.com/97251710/223034921-d6507277-782a-453c-8217-faa595fed966.gif)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

1. 한통신에 5초이상 걸릴시 에러발생
2. 통신에러 (500에러)시 4번 재시도하고 실패시 에러 발생
3. 에러 발생시 새로고침 혹은 메인페이지 이동하게 유도
