### PR TITLE
feat: 업체 상세 페이지를 SSG로 사전 로딩후 일정시간마다 변경되게 한다

### DIFF
--- a/components/Market/index.tsx
+++ b/components/Market/index.tsx
@@ -17,13 +17,12 @@ import MarketTitle from './marketTitle';
 
 export default function MarketProfile() {
   const router = useRouter();
-  const { status, data } = useQuery(
-    ['업체 상세 정보', router.query.id],
-    () => getMarketDetail({ enrollmentId: String(router.query.id) }),
-    { enabled: router.isReady }
+  const id = router.query.id as string;
+  const { status, data } = useQuery(['업체 상세 정보', id], () =>
+    getMarketDetail({ enrollmentId: id })
   );
 
-  if (status === 'loading' || !router.isReady) {
+  if (status === 'loading' || router.isFallback) {
     return <MarketProfileSkeleton />;
   }
 

--- a/components/Orders/Thread.tsx
+++ b/components/Orders/Thread.tsx
@@ -43,8 +43,7 @@ export default function Thread({ thread, orderId }: ThreadProps) {
       >
         <Link
           style={{ fontSize: '1rem', textDecoration: 'underline' }}
-          href="/market/[enrollmentId]"
-          as={`/market/${thread.enrollmentId}`}
+          href={`/market/${thread.enrollmentId}`}
         >
           {thread.marketName}
         </Link>

--- a/pages/api/enrollments/index.tsx
+++ b/pages/api/enrollments/index.tsx
@@ -10,7 +10,7 @@ export default async function postMarketList(
   try {
     const { cursor, category } = request.body;
     const { data }: AxiosResponse = await publicApi.get(
-      `/enrollments/?pageSize=10&cursor=${cursor}&status=${category}`
+      `/enrollments/?pageSize=10&cursorId=${cursor}&status=${category}`
     );
     return response.status(200).end(JSON.stringify(data));
   } catch (err) {

--- a/pages/main.tsx
+++ b/pages/main.tsx
@@ -68,7 +68,7 @@ export const getStaticProps = async () => {
         cursor: '',
       }),
     {
-      staleTime: 20000,
+      staleTime: 1000 * 60 * 1,
     }
   );
 
@@ -76,7 +76,7 @@ export const getStaticProps = async () => {
     props: {
       dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
       revalidate: 20,
-      fallback: false,
+      fallback: true,
     },
   };
 };

--- a/pages/market/[id].tsx
+++ b/pages/market/[id].tsx
@@ -9,24 +9,25 @@ export default function Market() {
 }
 
 export const getStaticPaths: GetStaticPaths = async () => ({
-  paths: [{ params: { id: 1 } }],
+  paths: [],
   fallback: true,
 });
 
-export const getStaticProps: GetStaticProps = async (params) => {
+export const getStaticProps: GetStaticProps = async (content) => {
   const queryClient = new QueryClient();
+  const id = content.params?.id as string;
 
   await queryClient.prefetchQuery(
-    ['업체 상세 정보', params.id],
-    () => getMarketDetail({ enrollmentId: String(params.id) }),
+    ['업체 상세 정보', id],
+    () => getMarketDetail({ enrollmentId: id }),
     {
-      staleTime: 20000,
+      staleTime: 1000 * 60 * 60,
     }
   );
 
   return {
     props: {
-      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+      dehydratedState: dehydrate(queryClient),
       revalidate: 86400,
     },
   };

--- a/pages/market/[id].tsx
+++ b/pages/market/[id].tsx
@@ -1,5 +1,33 @@
+import { dehydrate, QueryClient } from '@tanstack/react-query';
+import { GetStaticPaths, GetStaticProps } from 'next';
+
+import { getMarketDetail } from '@/components/Api/Market';
 import MarketProfile from '@/components/Market';
 
 export default function Market() {
   return <MarketProfile />;
 }
+
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: [{ params: { id: 1 } }],
+  fallback: true,
+});
+
+export const getStaticProps: GetStaticProps = async (params) => {
+  const queryClient = new QueryClient();
+
+  await queryClient.prefetchQuery(
+    ['업체 상세 정보', params.id],
+    () => getMarketDetail({ enrollmentId: String(params.id) }),
+    {
+      staleTime: 20000,
+    }
+  );
+
+  return {
+    props: {
+      dehydratedState: JSON.parse(JSON.stringify(dehydrate(queryClient))),
+      revalidate: 86400,
+    },
+  };
+};


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #164

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

### 리액트 쿼리의 SSG INIT 데이터 stale time : 1시간 

업체 정보는 자주 변하는 정보가 아님으로 보통 유저가 처음 접한이후 갱신이 필요하다 생각하지 않음


### 다이렉트로 서버에 접속 혹은 세로고침

데이터를 새로 불러오게 설정됨



### 기본적으로 ISR을 기반으로 1일 단위로 SSG파일을 갱신함

SSG의 경우 첫 Next build시 생성한 이후 변하지 않음
하지만 수정등의 요소를 반영하기 위해 만료시간을 1일으로 셋팅함 (봐서 변경가능)



### 데이터 (상점 데이터)를 가져오는 방식

기본적인 배열을 []으로 주고 fallback을 true로 셋팅함으로서
첫번째 로드시에는 로딩창을 보여주고 -> 서버에 SSG 페이지를 생성 (만료 1일)
이후 다른 유저나 동일한 유저가 만료기간내에 사이트에 접속하면
따로 데이터 통신없이 SSG 페이지를 불러오게 설정


## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome_ChdYYUffNN](https://user-images.githubusercontent.com/97251710/223687914-0c77ce61-8382-4914-aa36-93857c0e260d.gif)

## ✅ PR 포인트 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

이미지 때문인지 이유는 잘 모르겠지만 1일 이내의 데이터임에도 불구하고

지속적으로 통신이 일어날 때와 일어나지 않을 때가 있음

일부는 리액트 쿼리 (관리자를 통한 접속시)로 관리되고

일부 데이터는 리액트쿼리가 적용되지 않은 상태로 관리되는데 이 때 연관성이 있는 것 같음