### PR TITLE
feat: 관리자 페이지의 인증 인가를 관리한다

### DIFF
--- a/components/Api/Market.ts
+++ b/components/Api/Market.ts
@@ -5,7 +5,6 @@ import {
   PostMarketList,
 } from '@/types/Api';
 import { getAccessToken } from '@/utils/getAccessToken';
-import { getRoleFromToken } from '@/utils/getDecodeToken';
 
 import { internalApi } from '.';
 
@@ -51,7 +50,6 @@ export async function patchMarketStatus({
       status,
       enrollmentId,
     });
-    console.log(status, enrollmentId, token);
     if (response.status === 200) {
       return response.data;
     }

--- a/components/Api/Market.ts
+++ b/components/Api/Market.ts
@@ -4,6 +4,8 @@ import {
   PatchMarketStatus,
   PostMarketList,
 } from '@/types/Api';
+import { getAccessToken } from '@/utils/getAccessToken';
+import { getRoleFromToken } from '@/utils/getDecodeToken';
 
 import { internalApi } from '.';
 
@@ -42,10 +44,14 @@ export async function patchMarketStatus({
   enrollmentId,
 }: PatchMarketStatus) {
   try {
+    const token =
+      typeof window !== 'undefined' ? (getAccessToken() as string) : '';
     const response = await internalApi.patch(`/api/marketstatus`, {
+      token,
       status,
       enrollmentId,
     });
+    console.log(status, enrollmentId, token);
     if (response.status === 200) {
       return response.data;
     }

--- a/pages/admin/[id].tsx
+++ b/pages/admin/[id].tsx
@@ -3,9 +3,14 @@ import { GetStaticPaths, GetStaticProps } from 'next';
 
 import AdminMarketInfo from '@/components/Admin/adminMarketInfo';
 import { getMarketDetail } from '@/components/Api/Market';
+import AuthRequired from '@/utils/authRequire';
 
 export default function AdminMarket() {
-  return <AdminMarketInfo />;
+  return (
+    <AuthRequired>
+      <AdminMarketInfo />;
+    </AuthRequired>
+  );
 }
 
 export const getStaticPaths: GetStaticPaths = async () => ({

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -1,5 +1,10 @@
 import Admin from '@/components/Admin';
+import AuthRequired from '@/utils/authRequire';
 
 export default function AdminPage() {
-  return <Admin />;
+  return (
+    <AuthRequired>
+      <Admin />;
+    </AuthRequired>
+  );
 }

--- a/pages/api/marketstatus.tsx
+++ b/pages/api/marketstatus.tsx
@@ -8,10 +8,17 @@ export default async function patchMarketStatus(
   response: NextApiResponse
 ) {
   try {
-    const { status, enrollmentId } = request.body;
+    const { status, enrollmentId, token } = request.body;
     const { data }: AxiosResponse = await publicApi.patch(
       `/enrollments/${enrollmentId}`,
-      { status }
+      {
+        status,
+      },
+      {
+        headers: {
+          access_token: `${token}`,
+        },
+      }
     );
     return response.status(200).end(JSON.stringify(data));
   } catch (err) {

--- a/utils/authRequire.tsx
+++ b/utils/authRequire.tsx
@@ -1,0 +1,28 @@
+import { Box } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { FC, ReactNode, useEffect } from 'react';
+
+import { getAccessToken } from './getAccessToken';
+import { getRoleFromToken } from './getDecodeToken';
+
+interface AuthRequiredProps {
+  children: ReactNode;
+}
+
+// eslint-disable-next-line react/function-component-definition
+const AuthRequired: FC<AuthRequiredProps> = ({ children }) => {
+  const router = useRouter();
+  const token =
+    typeof window !== 'undefined' ? (getAccessToken() as string) : '';
+
+  useEffect(() => {
+    const role = getRoleFromToken(token);
+    if (token === '' || role !== 'ROLE_ADMIN') {
+      router.replace('/main');
+    }
+  }, [router, token]);
+
+  return <Box>{children}</Box>;
+};
+
+export default AuthRequired;


### PR DESCRIPTION
## 📌 이슈번호 <!-- 이슈번호 혹은 참조를 적어주세요 -->

- close #217

## 👩‍💻 요구 사항 <!-- 구현한 것을 간단하게 요약 , 코어 구현 로직 설명 -->

### 관리자 페이지

- [x] 로그인 상태에서는 /admin 페이지로 접근 및 관리 가능하다
- [x] 로그인 상태에서 신청업체의 조회 승인 삭제가 가능하다
- [x] 비로그인 시에는 /admin 페이지 접근 시 /으로 자동 리라우팅된다

## 🎨 구현 스크린샷 <!-- .gif 등을 사용하여 간단하게 보여주세요 -->
![chrome_M4iKKuTO13](https://user-images.githubusercontent.com/97251710/224652317-48cc465c-37d9-4e93-86fc-da51e527e6e6.gif)